### PR TITLE
(feat): add new task for project metadata

### DIFF
--- a/src/main/java/dev/shaaf/waver/Main.java
+++ b/src/main/java/dev/shaaf/waver/Main.java
@@ -322,12 +322,14 @@ public class Main implements Callable<Integer> {
         Path outputDir = Paths.get(appConfig.absoluteOutputPath() + "/" +appConfig.projectName());
 
 
+        // TODO: Consider passing AppConfig into the constructor so shared config is simplified across tasks.
         TaskPipeline tasksPipeLine = new TaskPipeline();
         tasksPipeLine.add(new CodeCrawlerTask())
                 .then(new IdentifyAbstractionsTask(chatModel, appConfig.projectName()))
                 .then(new IdentifyRelationshipsTask(chatModel, appConfig.projectName()))
                 .then(new ChapterOrganizerTask(chatModel))
-                .then(new TechnicalWriterTask(chatModel, outputDir));
+                .then(new TechnicalWriterTask(chatModel, outputDir))
+                .then(new MetaInfoTask(chatModel, outputDir, appConfig.projectName(), appConfig.inputPath()));
 
         logger.info("🚀 Starting Tutorial Generation for: " + appConfig.inputPath());
         String finalOutput = tasksPipeLine.run(appConfig.inputPath());

--- a/src/main/java/dev/shaaf/waver/Main.java
+++ b/src/main/java/dev/shaaf/waver/Main.java
@@ -319,7 +319,7 @@ public class Main implements Callable<Integer> {
     public static void generate(AppConfig appConfig) {
 
         ChatModel chatModel = ModelProviderFactory.buildChatModel(appConfig.llmProvider(), appConfig.apiKey());
-        Path outputDir = Paths.get(appConfig.absoluteOutputPath() + "/" + appConfig.llmProvider().name().toLowerCase() + "/" + appConfig.projectName() + "/" + System.currentTimeMillis());
+        Path outputDir = Paths.get(appConfig.absoluteOutputPath() + "/" +appConfig.projectName());
 
 
         TaskPipeline tasksPipeLine = new TaskPipeline();

--- a/src/main/java/dev/shaaf/waver/config/AppConfig.java
+++ b/src/main/java/dev/shaaf/waver/config/AppConfig.java
@@ -29,8 +29,6 @@ public record AppConfig(
 ) {
 
     public static final String DEFAULT_GITHUB_CLONE_PATH = System.getProperty("user.dir")+"/waver-git-clone/";
-    public static final String DEFAULT_OUTPUT_PATH = "output";
-    public static final String DEFAULT_PROJECT_NAME = "Wavers";
-    public static final OutputFormat DEFAULT_OUTPUT_FORMAT = OutputFormat.MARKDOWN;
+
 
 }

--- a/src/main/java/dev/shaaf/waver/config/AppConfig.java
+++ b/src/main/java/dev/shaaf/waver/config/AppConfig.java
@@ -26,4 +26,11 @@ public record AppConfig(
         boolean verbose,
         String projectName,
         OutputFormat outputFormat
-) {}
+) {
+
+    public static final String DEFAULT_GITHUB_CLONE_PATH = System.getProperty("user.dir")+"/waver-git-clone/";
+    public static final String DEFAULT_OUTPUT_PATH = "output";
+    public static final String DEFAULT_PROJECT_NAME = "Wavers";
+    public static final OutputFormat DEFAULT_OUTPUT_FORMAT = OutputFormat.MARKDOWN;
+
+}

--- a/src/main/java/dev/shaaf/waver/core/TaskPipeline.java
+++ b/src/main/java/dev/shaaf/waver/core/TaskPipeline.java
@@ -12,7 +12,7 @@ public class TaskPipeline {
 
     public TaskPipeline add(Task<?, ?> task) {
         String taskName = task.getName();
-        System.out.println("ADDING: " + taskName); // <-- Add this line
+        System.out.println("ADDING: " + taskName);
         if (tasks.containsKey(taskName)) {
             throw new IllegalArgumentException("Task '" + taskName + "' has already been added.");
         }

--- a/src/main/java/dev/shaaf/waver/tutorial/model/GenerationContext.java
+++ b/src/main/java/dev/shaaf/waver/tutorial/model/GenerationContext.java
@@ -8,23 +8,29 @@ public record GenerationContext(
         List<CodeFile> codeFiles,
         AbstractionList abstractions,
         RelationshipAnalysis relationshipAnalysis,
-        ChapterList chapterList
+        ChapterList chapterList,
+        TutorialMetadata metadata
 ) {
 
+
     public GenerationContext withCodeFiles(List<CodeFile> codeFiles) {
-        return new GenerationContext(codeFiles, this.abstractions, this.relationshipAnalysis, this.chapterList);
+        return new GenerationContext(codeFiles, this.abstractions, this.relationshipAnalysis, this.chapterList, this.metadata);
+    }
+
+    public GenerationContext withTutorialMetadata(TutorialMetadata metadata) {
+        return new GenerationContext(this.codeFiles, this.abstractions, this.relationshipAnalysis, this.chapterList, metadata);
     }
 
     public GenerationContext withAbstractions(AbstractionList abstractions) {
-        return new GenerationContext(this.codeFiles, abstractions, this.relationshipAnalysis, this.chapterList);
+        return new GenerationContext(this.codeFiles, abstractions, this.relationshipAnalysis, this.chapterList, this.metadata);
     }
 
     public GenerationContext withRelationshipAnalysis(RelationshipAnalysis relationshipAnalysis) {
-        return new GenerationContext(this.codeFiles, this.abstractions, relationshipAnalysis, this.chapterList);
+        return new GenerationContext(this.codeFiles, this.abstractions, relationshipAnalysis, this.chapterList, this.metadata);
     }
 
     public GenerationContext withChapterList(ChapterList chapterList) {
-        return new GenerationContext(this.codeFiles, this.abstractions, this.relationshipAnalysis, chapterList);
+        return new GenerationContext(this.codeFiles, this.abstractions, this.relationshipAnalysis, chapterList, this.metadata);
     }
 
 

--- a/src/main/java/dev/shaaf/waver/tutorial/model/TutorialMetadata.java
+++ b/src/main/java/dev/shaaf/waver/tutorial/model/TutorialMetadata.java
@@ -1,0 +1,22 @@
+package dev.shaaf.waver.tutorial.model;
+
+import java.util.List;
+import java.util.Optional;
+
+public record TutorialMetadata(
+        String title,
+        String description,
+        String repo,
+        String author,
+        String language,
+        List<String> tags,
+        String difficulty,
+        String estimatedTime,
+        List<String> prerequisites,
+        String lastUpdated
+) {
+
+    public TutorialMetadata withRepoOwner(String repoOwner) {
+        return new TutorialMetadata(title, description, repo, repoOwner, language, tags, difficulty, estimatedTime, prerequisites, lastUpdated);
+    }
+}

--- a/src/main/java/dev/shaaf/waver/tutorial/prompt/MetaInfoAnalyzer.java
+++ b/src/main/java/dev/shaaf/waver/tutorial/prompt/MetaInfoAnalyzer.java
@@ -1,0 +1,48 @@
+package dev.shaaf.waver.tutorial.prompt;
+
+import dev.langchain4j.service.SystemMessage;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import dev.shaaf.waver.tutorial.model.TutorialMetadata;
+
+
+public interface MetaInfoAnalyzer {
+    @SystemMessage("""
+            You are an expert technical writer and software architect responsible for creating metadata for programming tutorials. Your task is to analyze the provided codebase abstractions and repository URL to generate a structured JSON object that describes the tutorial.
+
+            Instructions:
+            Based on the inputs in the user message, generate a single JSON object with the following fields, adhering strictly to these definitions:
+
+            - "title": A concise, descriptive title for the tutorial.
+            - "description": A paragraph summarizing the project's goal, the technologies used, and what a developer will learn.
+            - "repo": The full repository URL provided as input.
+            - "author": Use "Stefan Shaaf" as the author name.
+            - "language": The primary programming language used in the codebase (e.g., "Java", "Python").
+            - "tags": An array of 5-7 relevant lowercase string tags. Include the language, main frameworks, and key concepts.
+            - "difficulty": Classify as one of: "beginner", "intermediate", or "hard".
+                - "beginner": For basic syntax or single, isolated concepts.
+                - "intermediate": For tutorials involving multiple frameworks or established architectural patterns.
+                - "hard": For tutorials on advanced topics like complex architecture or performance optimization.
+            - "estimatedTime": A rough estimate of the time required to complete the tutorial (e.g., "2 hours", "3 days").
+            - "prerequisites": An array of strings listing the skills a developer should have before starting.
+            - "lastUpdated": The current date and time in ISO 8601 format. Use "2025-08-04T21:51:21Z".
+
+            The final output must be a single, valid JSON object only. Do not add any text or explanations before or after the JSON block.
+            """)
+    @UserMessage("""
+            Please generate the JSON metadata by analyzing the following details:
+            ProjectName: {{projectName}}
+            
+            **1. Codebase Abstractions:**
+            {{abstractions}}
+
+            **2. Codebase Repository URL:**
+            {{codebase}}
+            """)
+    TutorialMetadata generateMetadata(
+            @V("codebase") String codebase,
+            @V("abstractions") String abstractions,
+            @V("projectName") String projectName
+    );
+
+}

--- a/src/main/java/dev/shaaf/waver/tutorial/task/CodeCrawlerTask.java
+++ b/src/main/java/dev/shaaf/waver/tutorial/task/CodeCrawlerTask.java
@@ -24,8 +24,9 @@ public class CodeCrawlerTask implements Task<String, GenerationContext> {
 
         if(inputType == InputType.GIT_URL){
             try {
-                return new GenerationContext(FetchRepo.crawl(GitHubRepoFetcher.getRepositoryName(inputString)), null, null, null);
+                return new GenerationContext(FetchRepo.crawl(GitHubRepoFetcher.getAndCloneRepo(inputString)), null, null, null);
             } catch (IOException e) {
+                e.printStackTrace();
                 throw new TaskRunException(e);
             }
         }

--- a/src/main/java/dev/shaaf/waver/tutorial/task/CodeCrawlerTask.java
+++ b/src/main/java/dev/shaaf/waver/tutorial/task/CodeCrawlerTask.java
@@ -3,6 +3,7 @@ package dev.shaaf.waver.tutorial.task;
 import dev.shaaf.waver.core.PipelineContext;
 import dev.shaaf.waver.core.Task;
 import dev.shaaf.waver.core.TaskRunException;
+import dev.shaaf.waver.tutorial.model.TutorialMetadata;
 import dev.shaaf.waver.util.files.FetchRepo;
 import dev.shaaf.waver.util.files.GitHubRepoFetcher;
 import dev.shaaf.waver.tutorial.model.GenerationContext;
@@ -24,7 +25,7 @@ public class CodeCrawlerTask implements Task<String, GenerationContext> {
 
         if(inputType == InputType.GIT_URL){
             try {
-                return new GenerationContext(FetchRepo.crawl(GitHubRepoFetcher.getAndCloneRepo(inputString)), null, null, null);
+                return new GenerationContext(FetchRepo.crawl(GitHubRepoFetcher.getAndCloneRepo(inputString)), null, null, null,null);
             } catch (IOException e) {
                 e.printStackTrace();
                 throw new TaskRunException(e);
@@ -32,7 +33,7 @@ public class CodeCrawlerTask implements Task<String, GenerationContext> {
         }
         else if(inputType == InputType.LOCAL_DIRECTORY){
             try {
-                return new GenerationContext(FetchRepo.crawl(inputString), null, null, null);
+                return new GenerationContext(FetchRepo.crawl(inputString), null, null, null, null);
             } catch (IOException e) {
                 throw new TaskRunException(e);
             }

--- a/src/main/java/dev/shaaf/waver/tutorial/task/MetaInfoTask.java
+++ b/src/main/java/dev/shaaf/waver/tutorial/task/MetaInfoTask.java
@@ -1,0 +1,56 @@
+package dev.shaaf.waver.tutorial.task;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.service.AiServices;
+import dev.shaaf.waver.core.PipelineContext;
+import dev.shaaf.waver.core.Task;
+import dev.shaaf.waver.core.TaskRunException;
+import dev.shaaf.waver.tutorial.model.GenerationContext;
+import dev.shaaf.waver.tutorial.model.TutorialMetadata;
+import dev.shaaf.waver.tutorial.prompt.MetaInfoAnalyzer;
+import dev.shaaf.waver.util.files.GitHubRepoFetcher;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+public class MetaInfoTask implements Task<GenerationContext, String> {
+
+    private ChatModel chatModel;
+    private Path outputDir;
+    private final String projectName;
+    private final String inputString;
+
+    public MetaInfoTask(ChatModel chatModel, Path outputDir, String projectName, String inputString){
+        this.projectName = projectName;
+        this.chatModel = chatModel;
+        this.outputDir = outputDir;
+        this.inputString = inputString;
+    }
+
+    @Override
+    public String execute(GenerationContext generationContext, PipelineContext context) throws TaskRunException {
+
+        MetaInfoAnalyzer infoAnalyzer = AiServices.create(MetaInfoAnalyzer.class, chatModel);
+        TutorialMetadata metadata = infoAnalyzer.generateMetadata(generationContext.codeAsString(), generationContext.abstractionsAsString(), projectName);
+
+        metadata = metadata.withRepoOwner((GitHubRepoFetcher.getOwnerFromUrl(inputString)).orElse("Unknown"));
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+
+        try{
+            if(Files.isDirectory(outputDir))
+                mapper.writeValue(outputDir.resolve("waver-config.json").toFile(), metadata);
+            else
+                throw new TaskRunException("Output directory not found " + outputDir.toAbsolutePath());
+        } catch (IOException e) {
+            throw new TaskRunException(e);
+        }
+
+        return "All is well, that ends well!";
+    }
+}

--- a/src/main/java/dev/shaaf/waver/tutorial/task/TechnicalWriterTask.java
+++ b/src/main/java/dev/shaaf/waver/tutorial/task/TechnicalWriterTask.java
@@ -17,7 +17,7 @@ import java.nio.file.Path;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
-public class TechnicalWriterTask implements Task<GenerationContext, String> {
+public class TechnicalWriterTask implements Task<GenerationContext, GenerationContext> {
     // Get a logger instance for this class
     private static final Logger logger = Logger.getLogger(TechnicalWriterTask.class.getName());
 
@@ -30,7 +30,7 @@ public class TechnicalWriterTask implements Task<GenerationContext, String> {
     }
 
     @Override
-    public String execute(GenerationContext generationContext, PipelineContext context) throws TaskRunException {
+    public GenerationContext execute(GenerationContext generationContext, PipelineContext context) throws TaskRunException {
 
         try{
             Files.createDirectories(outputDir);
@@ -48,7 +48,7 @@ public class TechnicalWriterTask implements Task<GenerationContext, String> {
             writeChapterToDisk(outputDir, "index.md", introChapterContent.toString());
             logger.info("✅ Tutorial generated at: " + outputDir.toAbsolutePath());
 
-            return "All is well, that ends well!";
+            return generationContext;
         } catch (IOException e) {
             throw new TaskRunException(e);
         }

--- a/src/main/java/dev/shaaf/waver/util/files/GitHubRepoFetcher.java
+++ b/src/main/java/dev/shaaf/waver/util/files/GitHubRepoFetcher.java
@@ -1,14 +1,17 @@
 package dev.shaaf.waver.util.files;
 
+import dev.shaaf.waver.config.AppConfig;
+import dev.shaaf.waver.core.TaskRunException;
 import dev.shaaf.waver.util.log.LogConfig;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.JGitInternalException;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class GitHubRepoFetcher {
 
@@ -19,11 +22,10 @@ public class GitHubRepoFetcher {
         LogConfig.setLoggingConfig(logger);
     }
 
-    public static String getRepositoryName(String gitRemoteUrl) throws IOException {
+    public static String getAndCloneRepo(String gitRemoteUrl) throws IOException {
 
-        Path tempDir = Path.of(System.getProperty("user.dir")+"/tmp");
+        Path tempDir = Path.of(AppConfig.DEFAULT_GITHUB_CLONE_PATH + getNameFromRemoteURL(gitRemoteUrl));
 
-        Files.createDirectories(tempDir);
         // The try-with-resources block ensures the Git object is properly closed.
         try (Git git = Git.cloneRepository()
                 .setURI(gitRemoteUrl)
@@ -40,6 +42,20 @@ public class GitHubRepoFetcher {
             throw new RuntimeException(e);
         }
 
-        return tempDir.getFileName().toString();
+        return tempDir.toAbsolutePath().toString();
+    }
+
+
+    public static String getNameFromRemoteURL(String urlString) {
+        Pattern REPO_PATTERN = Pattern.compile("^https?://[^/]+/(.*?)\\.git$");
+        Matcher matcher = REPO_PATTERN.matcher(urlString);
+
+        if (matcher.find()) {
+            // Group 1 contains our desired string
+            return matcher.group(1);
+        }
+
+        throw new TaskRunException("Unable to parse URL to create local copy: " + urlString);
+
     }
 }

--- a/src/main/java/dev/shaaf/waver/util/files/GitHubRepoFetcher.java
+++ b/src/main/java/dev/shaaf/waver/util/files/GitHubRepoFetcher.java
@@ -6,12 +6,18 @@ import dev.shaaf.waver.util.log.LogConfig;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.JGitInternalException;
+import org.eclipse.jgit.lib.PersonIdent;
+import org.eclipse.jgit.revwalk.RevCommit;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class GitHubRepoFetcher {
 
@@ -56,6 +62,42 @@ public class GitHubRepoFetcher {
         }
 
         throw new TaskRunException("Unable to parse URL to create local copy: " + urlString);
-
     }
+
+
+    public Set<String> getContributors(Path repoPath) throws IOException, GitAPIException {
+        Set<PersonIdent> contributors = new HashSet<>();
+
+        // Use try-with-resources to ensure the Git object is closed
+        try (Git git = Git.open(repoPath.toFile())) {
+            // Fetch all commits from the log
+            Iterable<RevCommit> commits = git.log().all().call();
+
+            // Iterate through commits and add unique authors
+            for (RevCommit commit : commits) {
+                contributors.add(commit.getAuthorIdent());
+            }
+        }
+
+        // Format the output for readability
+        return contributors.stream()
+                .map(person -> String.format("%s <%s>", person.getName(), person.getEmailAddress()))
+                .collect(Collectors.toSet());
+    }
+
+
+    public static Optional<String> getOwnerFromUrl(String repoUrl) {
+        Pattern OWNER_REPO_PATTERN = Pattern.compile("[:/]([^/]+/[^/]+?)(\\.git)?$");
+        Matcher matcher = OWNER_REPO_PATTERN.matcher(repoUrl);
+
+        if (matcher.find()) {
+            String ownerAndRepo = matcher.group(1); // e.g., "sshaaf/keycloak-mcp-server"
+            String[] parts = ownerAndRepo.split("/");
+            if (parts.length == 2) {
+                return Optional.of(parts[0]); // The owner is the first part
+            }
+        }
+        return Optional.empty();
+    }
+
 }

--- a/src/test/java/dev/shaaf/waver/util/files/GitHubRepoFetcherTest.java
+++ b/src/test/java/dev/shaaf/waver/util/files/GitHubRepoFetcherTest.java
@@ -1,6 +1,5 @@
 package dev.shaaf.waver.util.files;
 
-import dev.shaaf.waver.util.files.GitHubRepoFetcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -51,7 +50,7 @@ class GitHubRepoFetcherTest {
     void getRepositoryName_withValidPublicRepository_clonesSuccessfully() {
         assertDoesNotThrow(() -> {
             // Act: Call the method with a real Git URL
-            String result = GitHubRepoFetcher.getRepositoryName(VALID_PUBLIC_REPO_URL);
+            String result = GitHubRepoFetcher.getAndCloneRepo(VALID_PUBLIC_REPO_URL);
 
             // Assert
             assertEquals("tmp", result, "The method should return the name of the created directory.");
@@ -68,17 +67,24 @@ class GitHubRepoFetcherTest {
         // JGit throws a TransportException (subclass of GitAPIException) for a non-existent repo,
         // which the original code wraps in a RuntimeException.
         assertThrows(RuntimeException.class, () -> {
-            GitHubRepoFetcher.getRepositoryName(NON_EXISTENT_REPO_URL);
+            GitHubRepoFetcher.getAndCloneRepo(NON_EXISTENT_REPO_URL);
         }, "Cloning a non-existent repository should throw a RuntimeException.");
     }
 
     @Test
     @DisplayName("Should throw an exception when the URL is null")
-    void getRepositoryName_withNullUrl_throwsException() {
+    void getAndCloneRepo_withNullUrl_throwsException() {
         // Act & Assert
         // The underlying JGit library will throw an exception if the URI is null.
         assertThrows(RuntimeException.class, () -> {
-            GitHubRepoFetcher.getRepositoryName(null);
+            GitHubRepoFetcher.getAndCloneRepo(null);
         }, "A null URL should cause an exception.");
+    }
+
+    @Test
+    @DisplayName("Should successfully check a valid public repository and return the user/repo name without git")
+    void getNameFromRemoteURL() {
+        assertEquals("sshaaf/keycloak-mcp-server", GitHubRepoFetcher.getNameFromRemoteURL("https://github.com/sshaaf/keycloak-mcp-server.git"));
+
     }
 }


### PR DESCRIPTION
Adds a new task to get metadata and write a waver-config.json
e.g. 
```
{
  "title" : "Keycloak MCP Server: Managing Identity Providers, Roles, Groups, and Users",
  "description" : "This tutorial introduces you to the Keycloak MCP Server project, which is designed to manage identity providers, user roles, groups, and more using Keycloak. Built using Java and the Quarkus framework, developers will learn how to implement various services including user management, role definition, group handling, and authentication flow management. You'll also learn to utilize RESTful APIs to interact with Keycloak and integrate its functionalities in your applications.",
  "repo" : "https://github.com/sshaaf/keycloak-mcp-server",
  "author" : "sshaaf",
  "language" : "Java",
  "tags" : [ "java", "keycloak", "quarkus", "identity-management", "user-management", "authentication", "roles" ],
  "difficulty" : "intermediate",
  "estimatedTime" : "4 hours",
  "prerequisites" : [ "Basic understanding of Java programming", "Familiarity with RESTful APIs", "Basic knowledge of Keycloak", "Experience with the Quarkus framework" ],
  "lastUpdated" : "2025-08-04T21:51:21Z"
}
```